### PR TITLE
Add Docker Container subcommands

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,6 @@
 use includedir_codegen::Compression;
 use std::path::Path;
-use std::{fs, env};
+use std::{env, fs};
 fn main() {
     includedir_codegen::start("DAPP_FILES")
         .dir("templates/", Compression::Gzip)
@@ -9,13 +9,9 @@ fn main() {
 
     let out_dir = env::var_os("OUT_DIR").unwrap();
     let dest_path = Path::new(&out_dir).join("simple_udt");
-   
-    
+
     let sudt_bin = fs::read(Path::new("./builtins/bins/simple_udt")).unwrap();
     assert!(!sudt_bin.is_empty());
 
-    fs::write(
-        &dest_path,
-        sudt_bin
-    ).unwrap();
+    fs::write(&dest_path, sudt_bin).unwrap();
 }

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -336,7 +336,6 @@ impl DockerCommand<DockerContainer<'_>> {
     pub fn start<'a>(
         container: &'a DockerContainer,
     ) -> DockerResult<DockerCommand<DockerContainer<'a>>> {
-        println!("This is the Container Start function!");
         let cmd = format!("container start {}", &container.name);
         Ok(DockerCommand::<DockerContainer> {
             command_string: Some(cmd),
@@ -344,20 +343,44 @@ impl DockerCommand<DockerContainer<'_>> {
         })
     }
 
-    pub fn stop(_container: &DockerContainer) -> DockerResult<()> {
-        todo!()
+    pub fn stop<'a>(
+        container: &'a DockerContainer,
+    ) -> DockerResult<DockerCommand<DockerContainer<'a>>> {
+        let cmd = format!("container stop {}", &container.name);
+        Ok(DockerCommand::<DockerContainer> {
+            command_string: Some(cmd),
+            _docker: PhantomData::<DockerContainer>,
+        })
     }
 
-    pub fn pause(_container: &DockerContainer) -> DockerResult<()> {
-        todo!()
+    pub fn pause<'a>(
+        container: &'a DockerContainer,
+    ) -> DockerResult<DockerCommand<DockerContainer<'a>>> {
+        let cmd = format!("container pause {}", &container.name);
+        Ok(DockerCommand::<DockerContainer> {
+            command_string: Some(cmd),
+            _docker: PhantomData::<DockerContainer>,
+        })
     }
 
-    pub fn unpause(_container: &DockerContainer) -> DockerResult<()> {
-        todo!()
+    pub fn unpause<'a>(
+        container: &'a DockerContainer,
+    ) -> DockerResult<DockerCommand<DockerContainer<'a>>> {
+        let cmd = format!("container unpause {}", &container.name);
+        Ok(DockerCommand::<DockerContainer> {
+            command_string: Some(cmd),
+            _docker: PhantomData::<DockerContainer>,
+        })
     }
 
-    pub fn restart(_container: &DockerContainer) -> DockerResult<()> {
-        todo!()
+    pub fn restart<'a>(
+        container: &'a DockerContainer,
+    ) -> DockerResult<DockerCommand<DockerContainer<'a>>> {
+        let cmd = format!("container restart {}", &container.name);
+        Ok(DockerCommand::<DockerContainer> {
+            command_string: Some(cmd),
+            _docker: PhantomData::<DockerContainer>,
+        })
     }
 }
 
@@ -537,10 +560,49 @@ mod tests {
     fn test_container_start() {
         let container = dummy_container();
         let cmd = DockerCommand::<DockerContainer>::start(&container).unwrap();
-        println!("{:?}", cmd);
         assert_eq!(
             cmd.command_string.as_ref().unwrap().as_str(),
             format!("container start {}", container.name)
+        );
+    }
+
+    #[test]
+    fn test_container_stop() {
+        let container = dummy_container();
+        let cmd = DockerCommand::<DockerContainer>::stop(&container).unwrap();
+        assert_eq!(
+            cmd.command_string.as_ref().unwrap().as_str(),
+            format!("container stop {}", container.name)
+        );
+    }
+
+    #[test]
+    fn test_container_pause() {
+        let container = dummy_container();
+        let cmd = DockerCommand::<DockerContainer>::pause(&container).unwrap();
+        assert_eq!(
+            cmd.command_string.as_ref().unwrap().as_str(),
+            format!("container pause {}", container.name)
+        );
+    }
+
+    #[test]
+    fn test_container_unpause() {
+        let container = dummy_container();
+        let cmd = DockerCommand::<DockerContainer>::unpause(&container).unwrap();
+        assert_eq!(
+            cmd.command_string.as_ref().unwrap().as_str(),
+            format!("container unpause {}", container.name)
+        );
+    }
+
+    #[test]
+    fn test_container_restart() {
+        let container = dummy_container();
+        let cmd = DockerCommand::<DockerContainer>::restart(&container).unwrap();
+        assert_eq!(
+            cmd.command_string.as_ref().unwrap().as_str(),
+            format!("container restart {}", container.name)
         );
     }
 

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -337,7 +337,7 @@ impl DockerCommand<DockerContainer<'_>> {
         container: &'a DockerContainer,
     ) -> DockerResult<DockerCommand<DockerContainer<'a>>> {
         println!("This is the Container Start function!");
-        let cmd = format!("container stop {}", &container.name);
+        let cmd = format!("container start {}", &container.name);
         Ok(DockerCommand::<DockerContainer> {
             command_string: Some(cmd),
             _docker: PhantomData::<DockerContainer>,
@@ -540,7 +540,7 @@ mod tests {
         println!("{:?}", cmd);
         assert_eq!(
             cmd.command_string.as_ref().unwrap().as_str(),
-            format!("container stop {}", container.name)
+            format!("container start {}", container.name)
         );
     }
 


### PR DESCRIPTION
`DockerCommand::<DockerContainer>` now includes `start`, `stop`, `restart`, `pause`, `unpause`, `cp_to` and `cp_from` methods.

There might be a better way to handle the `cp` command and unify both.