### PR TITLE
account creation with encryption support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "aes"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfe0133578c0986e1fe3dfcd4af1cc5b2dd6c3dbf534d69916ce16a2701d40ba"
+dependencies = [
+ "cfg-if",
+ "cipher 0.4.3",
+ "cpufeatures",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,7 +226,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01b72a433d0cf2aef113ba70f62634c56fddb0f244e6377185c56a7cadbd8f91"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.3.0",
  "cpufeatures",
  "zeroize",
 ]
@@ -228,7 +239,7 @@ checksum = "3b84ed6d1d5f7aa9bdde921a5090e0ca4d934d250ea3b402a5fab3a994e28a2a"
 dependencies = [
  "aead",
  "chacha20",
- "cipher",
+ "cipher 0.3.0",
  "poly1305",
  "zeroize",
 ]
@@ -274,6 +285,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
  "generic-array 0.14.5",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -357,7 +378,7 @@ version = "0.101.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d0a421bc5fbf673116d565ef6d1f57251b1623cc7e6b6cd28559baf52c39f23"
 dependencies = [
- "ckb-fixed-hash",
+ "ckb-fixed-hash 0.101.4",
  "faster-hex",
  "lazy_static",
  "rand 0.7.3",
@@ -407,8 +428,18 @@ version = "0.101.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa108c61eb6171d3fdadc321517a3b407c54fb798ca6265e4dd65942cbc4a596"
 dependencies = [
- "ckb-fixed-hash-core",
- "ckb-fixed-hash-macros",
+ "ckb-fixed-hash-core 0.101.4",
+ "ckb-fixed-hash-macros 0.101.4",
+]
+
+[[package]]
+name = "ckb-fixed-hash"
+version = "0.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8c0a11805f5546d7a9b7b9deb15aa2eab338067bbca57577a91bb1576f74640"
+dependencies = [
+ "ckb-fixed-hash-core 0.102.0",
+ "ckb-fixed-hash-macros 0.102.0",
 ]
 
 [[package]]
@@ -423,12 +454,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "ckb-fixed-hash-core"
+version = "0.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3ccd93f2d6a953350d215093afcd061a8fbe870f89cc79f330d853201600c8"
+dependencies = [
+ "faster-hex",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "ckb-fixed-hash-macros"
 version = "0.101.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab9cdbce2196749e09f885065402b53ef75820c9b22422d96c8ab00a7a92a746"
 dependencies = [
- "ckb-fixed-hash-core",
+ "ckb-fixed-hash-core 0.101.4",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ckb-fixed-hash-macros"
+version = "0.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75641bfde0a29ebee5d46c9a71d8c1a5fdb1fb03447201dea4ad54c3bcc78b42"
+dependencies = [
+ "ckb-fixed-hash-core 0.102.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -660,7 +714,7 @@ dependencies = [
  "bytes",
  "ckb-channel",
  "ckb-error",
- "ckb-fixed-hash",
+ "ckb-fixed-hash 0.101.4",
  "ckb-hash",
  "ckb-occupied-capacity",
  "ckb-rational",
@@ -816,6 +870,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -823,6 +883,15 @@ checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
 dependencies = [
  "generic-array 0.14.5",
  "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d14f329cfbaf5d0e06b5e87fff7e265d2673c5ea7d2c27691a2c107db1442a0"
+dependencies = [
+ "cipher 0.4.3",
 ]
 
 [[package]]
@@ -1377,6 +1446,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array 0.14.5",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1801,6 +1879,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecba01bf2678719532c5e3059e0b5f0811273d94b397088b82e3bd0a78c78fdd"
 
 [[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest 0.10.3",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2184,6 +2271,18 @@ dependencies = [
  "spin",
  "untrusted",
  "web-sys",
+ "winapi",
+]
+
+[[package]]
+name = "rpassword"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf099a1888612545b683d2661a1940089f6c2e5a8e38979b2159da876bfd956"
+dependencies = [
+ "libc",
+ "serde",
+ "serde_json",
  "winapi",
 ]
 
@@ -2631,6 +2730,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2780,6 +2888,7 @@ dependencies = [
  "phf 0.8.0",
  "rand 0.8.5",
  "reqwest",
+ "rpassword",
  "secp256k1 0.19.0",
  "serde",
  "serde_json",
@@ -2797,6 +2906,7 @@ dependencies = [
 name = "trampoline-sdk"
 version = "0.1.0"
 dependencies = [
+ "aes",
  "anyhow",
  "blake2b-rs",
  "bytes",
@@ -2805,6 +2915,7 @@ dependencies = [
  "ckb-chain-spec",
  "ckb-crypto",
  "ckb-error",
+ "ckb-fixed-hash 0.102.0",
  "ckb-hash",
  "ckb-jsonrpc-types",
  "ckb-resource",
@@ -2816,20 +2927,26 @@ dependencies = [
  "ckb-types",
  "ckb-util",
  "ckb-verification",
+ "ctr",
  "hex",
+ "hmac",
  "includedir",
  "jsonrpc-core",
  "lazy_static",
  "molecule",
  "molecule-codegen",
+ "pbkdf2",
  "phf 0.10.1",
  "rand 0.8.5",
  "reqwest",
  "secp256k1 0.20.3",
  "serde",
  "serde_json",
+ "sha2",
  "structopt",
+ "tempfile",
  "thiserror",
+ "tiny-keccak",
  "tokio",
  "toml",
  "walkdir",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,12 +434,12 @@ dependencies = [
 
 [[package]]
 name = "ckb-fixed-hash"
-version = "0.102.0"
+version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8c0a11805f5546d7a9b7b9deb15aa2eab338067bbca57577a91bb1576f74640"
+checksum = "87e16c26d073b6ce9820154d8fb067d95dbfcb91faa693162341e90f26c3363f"
 dependencies = [
- "ckb-fixed-hash-core 0.102.0",
- "ckb-fixed-hash-macros 0.102.0",
+ "ckb-fixed-hash-core 0.103.0",
+ "ckb-fixed-hash-macros 0.103.0",
 ]
 
 [[package]]
@@ -455,9 +455,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-fixed-hash-core"
-version = "0.102.0"
+version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3ccd93f2d6a953350d215093afcd061a8fbe870f89cc79f330d853201600c8"
+checksum = "14c7cda98b0ed0f7c46788e5399b1c69423cad02cf9b8f9f77e3ed7cfbd95dcc"
 dependencies = [
  "faster-hex",
  "serde",
@@ -478,11 +478,11 @@ dependencies = [
 
 [[package]]
 name = "ckb-fixed-hash-macros"
-version = "0.102.0"
+version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75641bfde0a29ebee5d46c9a71d8c1a5fdb1fb03447201dea4ad54c3bcc78b42"
+checksum = "bcc8f5a4d66e01da9f8024aea5a49ee0c93f7a927e932b37c162c7afd38959f4"
 dependencies = [
- "ckb-fixed-hash-core 0.102.0",
+ "ckb-fixed-hash-core 0.103.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -2915,7 +2915,7 @@ dependencies = [
  "ckb-chain-spec",
  "ckb-crypto",
  "ckb-error",
- "ckb-fixed-hash 0.102.0",
+ "ckb-fixed-hash 0.103.0",
  "ckb-hash",
  "ckb-jsonrpc-types",
  "ckb-resource",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ toml = "0.5.8"
 walkdir = "2.3.2"
 trampoline-sdk = {path = "./sdk"}
 secp256k1 = "0.19.0"
+rpassword = "6.0.1"
 
 
 [build-dependencies]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -42,4 +42,13 @@ toml = { version = "0.5.8"}
 walkdir = { version = "2.3.2"}
 ckb-standalone-types = { version = "0.1.2", default-features = false}
 secp256k1 = { version = "0.20", features = ["recovery"] }
+ctr = "0.9.1"
+aes = "0.8.1"
+sha2 = "0.10.2"
+pbkdf2 = { version = "0.11", default-features = false }
+hmac = "0.12.1"
+tiny-keccak = { version = "2.0.0", features = ["keccak"] }
+ckb-fixed-hash = "0.102.0"
 
+[dev-dependencies]
+tempfile = "3.3.0"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -48,7 +48,7 @@ sha2 = "0.10.2"
 pbkdf2 = { version = "0.11", default-features = false }
 hmac = "0.12.1"
 tiny-keccak = { version = "2.0.0", features = ["keccak"] }
-ckb-fixed-hash = "0.102.0"
+ckb-fixed-hash = "0.103.0"
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/sdk/src/account/crypto.rs
+++ b/sdk/src/account/crypto.rs
@@ -1,0 +1,342 @@
+use crate::account::error::AccountError;
+use aes::cipher::{KeyIvInit, StreamCipher};
+use anyhow::Result;
+use hmac::Hmac;
+use pbkdf2::pbkdf2;
+use rand::Rng;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use tiny_keccak::Hasher;
+
+// https://github.com/ethereum/wiki/wiki/Web3-Secret-Storage-Definition#pbkdf2-sha-256
+const PBKDF2_DKLEN: u32 = 32;
+const PBKDF2_C: u32 = 262144;
+const KDF_TYPE_PBKDF2: &str = "pbkdf2";
+
+const CIPHER_AES128CTR: &str = "aes-128-ctr";
+
+type Aes128Ctr = ctr::Ctr128BE<aes::Aes128>;
+
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
+pub enum Prf {
+    #[serde(rename = "hmac-sha256")]
+    HmacSha256,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct Pbkdf2 {
+    prf: Prf,
+    #[serde(
+        serialize_with = "serialize_bytes",
+        deserialize_with = "deserialize_bytes_32"
+    )]
+    salt: [u8; 32],
+    c: u32,
+    dklen: u32,
+}
+
+impl Default for Pbkdf2 {
+    fn default() -> Self {
+        Pbkdf2 {
+            prf: Prf::HmacSha256,
+            salt: rand::thread_rng().gen(),
+            c: PBKDF2_C,
+            dklen: PBKDF2_DKLEN,
+        }
+    }
+}
+
+impl Pbkdf2 {
+    pub fn new_with_salt(salt: [u8; 32]) -> Self {
+        Pbkdf2 {
+            salt,
+            ..Default::default()
+        }
+    }
+    pub fn pdf_key(&self, password: &[u8]) -> [u8; 32] {
+        let mut res = [0u8; 32];
+        pbkdf2::<Hmac<sha2::Sha256>>(password, self.salt.as_slice(), self.c, &mut res);
+        res
+    }
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kdf", content = "kdfparams", rename_all = "lowercase")]
+pub enum Kdf {
+    Pbkdf2(Pbkdf2),
+}
+
+impl Default for Kdf {
+    fn default() -> Self {
+        Kdf::Pbkdf2(Pbkdf2::default())
+    }
+}
+
+impl Kdf {
+    pub fn kdf_key(&self, password: &[u8]) -> [u8; 32] {
+        match self {
+            Kdf::Pbkdf2(params) => params.pdf_key(password),
+        }
+    }
+
+    pub fn kdf_type(&self) -> &'static str {
+        match self {
+            Kdf::Pbkdf2(_) => KDF_TYPE_PBKDF2,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "cipher", content = "cipherparams")]
+pub enum Cipher {
+    #[serde(rename = "aes-128-ctr")]
+    Aes128Ctr(Aes128CtrParams),
+}
+
+impl Default for Cipher {
+    fn default() -> Self {
+        Cipher::Aes128Ctr(Aes128CtrParams::default())
+    }
+}
+
+impl Cipher {
+    pub fn cipher_type(&self) -> &'static str {
+        CIPHER_AES128CTR
+    }
+
+    pub fn encrypt_inplace(&self, key: &[u8], data: &mut [u8]) {
+        self.apply_inplace(key, data)
+    }
+
+    pub fn decrypt_inplace(&self, key: &[u8], data: &mut [u8]) {
+        self.apply_inplace(key, data)
+    }
+
+    // The code of encryption and decryption of aes-1280-ctr is same.
+    fn apply_inplace(&self, key: &[u8], data: &mut [u8]) {
+        match self {
+            Cipher::Aes128Ctr(p) => {
+                assert!(key.len() >= 16);
+                let mut cipher = Aes128Ctr::new(key[..16].into(), p.iv.as_slice().into());
+                cipher.apply_keystream(data);
+            }
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct Aes128CtrParams {
+    #[serde(
+        serialize_with = "serialize_bytes",
+        deserialize_with = "deserialize_bytes_16"
+    )]
+    iv: [u8; 16],
+}
+
+impl Default for Aes128CtrParams {
+    fn default() -> Self {
+        Aes128CtrParams {
+            iv: rand::thread_rng().gen(),
+        }
+    }
+}
+
+impl Aes128CtrParams {
+    pub fn new(iv: [u8; 16]) -> Self {
+        Aes128CtrParams { iv }
+    }
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct Crypto {
+    #[serde(flatten)]
+    cipher: Cipher,
+    #[serde(
+        serialize_with = "serialize_bytes",
+        deserialize_with = "deserialize_bytes"
+    )]
+    ciphertext: Vec<u8>,
+    #[serde(flatten)]
+    kdf: Kdf,
+    #[serde(
+        serialize_with = "serialize_bytes",
+        deserialize_with = "deserialize_bytes_32"
+    )]
+    mac: [u8; 32],
+}
+
+impl Crypto {
+    pub fn encrypt_key(key: &[u8], password: &[u8]) -> Crypto {
+        Crypto::encrypt_key_with_kdf_and_cipher(key, password, Kdf::default(), Cipher::default())
+    }
+
+    pub fn encrypt_key_with_kdf_and_cipher(
+        key: &[u8],
+        password: &[u8],
+        kdf: Kdf,
+        cipher: Cipher,
+    ) -> Crypto {
+        let kdf_key = kdf.kdf_key(password);
+        let mut ciphertext = key.to_vec();
+        cipher.encrypt_inplace(&kdf_key, &mut ciphertext);
+        let mac = calculate_mac(&ciphertext, &kdf_key);
+        Crypto {
+            cipher,
+            kdf,
+            ciphertext,
+            mac,
+        }
+    }
+
+    pub fn decrypt_key(&self, password: &[u8]) -> Result<Vec<u8>, AccountError> {
+        let mut plain_text = self.ciphertext.clone();
+        let kdf_key = self.kdf.kdf_key(password);
+        let mac = calculate_mac(&self.ciphertext, &kdf_key);
+        if mac != self.mac {
+            return Err(AccountError::WrongPassword);
+        }
+
+        self.cipher.decrypt_inplace(&kdf_key, &mut plain_text);
+        Ok(plain_text)
+    }
+}
+
+fn calculate_mac(ciphertext: &[u8], kdf_key: &[u8; 32]) -> [u8; 32] {
+    let ciphertext_len = ciphertext.len();
+    let mut mac_bytes = vec![0u8; 16 + ciphertext_len];
+    mac_bytes[..16].copy_from_slice(&kdf_key[16..]);
+    mac_bytes[16..16 + ciphertext_len].copy_from_slice(ciphertext);
+    let mut output = [0u8; 32];
+    let mut hasher = tiny_keccak::Keccak::v256();
+    hasher.update(&mac_bytes);
+    hasher.finalize(&mut output);
+    output
+}
+
+macro_rules! impl_deserialize_bytes {
+    ($name: ident, $size: expr) => {
+        pub fn $name<'de, D>(deserializer: D) -> Result<[u8; $size], D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            let s = String::deserialize(deserializer)?;
+            let mut res = [0u8; $size];
+            hex::decode_to_slice(s, &mut res).map_err(serde::de::Error::custom)?;
+            Ok(res)
+        }
+    };
+}
+impl_deserialize_bytes!(deserialize_bytes_32, 32);
+impl_deserialize_bytes!(deserialize_bytes_16, 16);
+
+pub fn serialize_bytes<S>(data: &[u8], serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_str(&hex::encode(data))
+}
+
+pub fn deserialize_bytes<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    hex::decode(s).map_err(serde::de::Error::custom)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::account::key::Generator;
+    use serde_json::Value;
+
+    struct Fixture {
+        json_data: Value,
+        password: Vec<u8>,
+        key: [u8; 32],
+    }
+
+    // https://github.com/ethereum/wiki/wiki/Web3-Secret-Storage-Definition#pbkdf2-sha-256
+    fn fixture() -> Fixture {
+        let json_str = r#"
+        {
+            "cipher" : "aes-128-ctr",
+            "cipherparams" : {
+                "iv" : "6087dab2f9fdbbfaddc31a909735c1e6"
+            },
+            "ciphertext" : "5318b4d5bcd28de64ee5559e671353e16f075ecae9f99c7a79a38af5f869aa46",
+            "kdf" : "pbkdf2",
+            "kdfparams" : {
+                "c" : 262144,
+                "dklen" : 32,
+                "prf" : "hmac-sha256",
+                "salt" : "ae3cd4e7013836a3df6bd7241b12db061dbe2c6785853cce422d148a624ce0bd"
+            },
+            "mac" : "517ead924a9d0dc3124507e3393d175ce3ff7c1e96529c6c555ce9e51205e9b2"
+        }"#;
+        let mut key = [0u8; 32];
+        hex::decode_to_slice(
+            "7a28b5ba57c53603b0b07b56bba752f7784bf506fa95edc395f5cf6c7514fe9d",
+            &mut key,
+        )
+        .unwrap();
+        Fixture {
+            json_data: serde_json::from_str(json_str).unwrap(),
+            password: b"testpassword".to_vec(),
+            key,
+        }
+    }
+
+    #[test]
+    fn test_decrypt() {
+        let fixture = fixture();
+        let crypto: Crypto = serde_json::from_value(fixture.json_data).unwrap();
+        let key = crypto.decrypt_key(fixture.password.as_slice()).unwrap();
+        assert_eq!(key, fixture.key);
+
+        let result = crypto.decrypt_key("wrongpassword".as_bytes());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_encrypt() {
+        let fixture = fixture();
+        let mut salt = [0u8; 32];
+        hex::decode_to_slice(
+            fixture.json_data["kdfparams"]["salt"].as_str().unwrap(),
+            &mut salt,
+        )
+        .unwrap();
+        let kdf = Kdf::Pbkdf2(Pbkdf2::new_with_salt(salt));
+
+        let mut iv = [0u8; 16];
+        hex::decode_to_slice(
+            fixture.json_data["cipherparams"]["iv"].as_str().unwrap(),
+            &mut iv,
+        )
+        .unwrap();
+        let cipher = Cipher::Aes128Ctr(Aes128CtrParams::new(iv));
+
+        let password = "testpassword".as_bytes();
+
+        let crypto = Crypto::encrypt_key_with_kdf_and_cipher(&fixture.key, password, kdf, cipher);
+        assert_eq!(
+            hex::encode(crypto.ciphertext),
+            fixture.json_data["ciphertext"].as_str().unwrap()
+        );
+        assert_eq!(
+            hex::encode(crypto.mac),
+            fixture.json_data["mac"].as_str().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_json() {
+        let keypair = Generator::default().generate();
+        let crypto: Crypto = Crypto::encrypt_key(keypair.secret().as_bytes(), &[]);
+        let json_str = serde_json::to_string_pretty(&crypto).unwrap();
+
+        let crypto2: Crypto = serde_json::from_str(&json_str).unwrap();
+
+        assert_eq!(crypto, crypto2)
+    }
+}

--- a/sdk/src/account/error.rs
+++ b/sdk/src/account/error.rs
@@ -1,0 +1,20 @@
+use std::io;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum AccountError {
+    #[error("Wrong password")]
+    WrongPassword,
+
+    #[error("Invalid key length")]
+    InvalidKeyLength,
+
+    #[error("Invalid key")]
+    InvalidKey(#[from] secp256k1::Error),
+
+    #[error("IO error")]
+    Io(#[from] io::Error),
+
+    #[error("JSON error")]
+    Json(#[from] serde_json::Error),
+}

--- a/sdk/src/account/key.rs
+++ b/sdk/src/account/key.rs
@@ -1,0 +1,205 @@
+use ckb_fixed_hash::H512;
+use ckb_types::{H160, H256};
+use lazy_static::lazy_static;
+use rand::Rng;
+use std::{
+    fmt,
+    fmt::{Debug, Formatter},
+    ops::Deref,
+    str::FromStr,
+};
+
+use crate::account::error::AccountError;
+
+lazy_static! {
+    static ref SECP256K1: secp256k1::Secp256k1<secp256k1::All> = secp256k1::Secp256k1::new();
+}
+
+pub type LockArg = H160;
+
+#[derive(Default)]
+pub struct Secret {
+    inner: H256,
+}
+
+impl Secret {
+    pub fn from_slice(data: &[u8]) -> Result<Secret, AccountError> {
+        if data.len() != 32 {
+            return Err(AccountError::InvalidKeyLength);
+        }
+        let mut h = [0u8; 32];
+        h.copy_from_slice(&data[..32]);
+        Ok(Secret { inner: h.into() })
+    }
+
+    pub fn public_key(&self) -> Result<Public, AccountError> {
+        let pk = secp256k1::PublicKey::from_secret_key(&SECP256K1, &self.to_secp256k1_secret()?);
+        Ok(pk.into())
+    }
+
+    fn to_secp256k1_secret(&self) -> Result<secp256k1::SecretKey, AccountError> {
+        secp256k1::SecretKey::from_slice(self.inner.as_bytes()).map_err(Into::into)
+    }
+}
+
+impl FromStr for Secret {
+    type Err = AccountError;
+
+    fn from_str(s: &str) -> Result<Secret, Self::Err> {
+        let sk = secp256k1::SecretKey::from_str(s)?;
+        Ok(sk.into())
+    }
+}
+
+impl fmt::LowerHex for Secret {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        fmt::LowerHex::fmt(&self.inner, f)
+    }
+}
+
+impl Deref for Secret {
+    type Target = H256;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl From<secp256k1::SecretKey> for Secret {
+    fn from(key: secp256k1::SecretKey) -> Self {
+        let mut h = [0u8; 32];
+        h.copy_from_slice(&key[0..32]);
+        Secret { inner: h.into() }
+    }
+}
+
+pub struct Public {
+    inner: H512,
+}
+
+impl Public {
+    pub fn from_slice(data: &[u8]) -> Result<Public, AccountError> {
+        Ok(secp256k1::PublicKey::from_slice(data)?.into())
+    }
+
+    pub fn to_lock_arg(&self) -> Result<LockArg, AccountError> {
+        let pk = self.to_secp256k1_public()?;
+        let lock_arg = H160::from_slice(&ckb_hash::blake2b_256(&pk.serialize()[..])[0..20])
+            .map_err(|_| AccountError::InvalidKeyLength)?;
+        Ok(lock_arg)
+    }
+
+    fn to_secp256k1_public(&self) -> Result<secp256k1::PublicKey, AccountError> {
+        // uncompressed key prefix is 4
+        let mut data = [4u8; 65];
+        data[1..65].copy_from_slice(self.as_bytes());
+        secp256k1::PublicKey::from_slice(&data).map_err(Into::into)
+    }
+}
+
+impl fmt::LowerHex for Public {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        fmt::LowerHex::fmt(&self.inner, f)
+    }
+}
+
+impl From<secp256k1::PublicKey> for Public {
+    fn from(key: secp256k1::PublicKey) -> Self {
+        let serialized = key.serialize_uncompressed();
+        let mut pubkey = [0u8; 64];
+        pubkey.copy_from_slice(&serialized[1..65]);
+        Public {
+            inner: pubkey.into(),
+        }
+    }
+}
+
+impl Deref for Public {
+    type Target = H512;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+pub struct KeyPair {
+    secret: Secret,
+    public: Public,
+}
+
+impl KeyPair {
+    pub fn from_secret_slice(sk: &[u8]) -> Result<Self, AccountError> {
+        let secret = Secret::from_slice(sk)?;
+        let public = secret.public_key()?;
+        Ok(KeyPair { secret, public })
+    }
+
+    pub fn from_secret_str(sk: String) -> Result<Self, AccountError> {
+        let secret = Secret::from_str(&sk)?;
+        let public = secret.public_key()?;
+        Ok(KeyPair { secret, public })
+    }
+
+    pub fn secret(&self) -> &Secret {
+        &self.secret
+    }
+
+    pub fn public(&self) -> &Public {
+        &self.public
+    }
+
+    pub fn lock_arg(&self) -> Result<LockArg, AccountError> {
+        self.public.to_lock_arg()
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct Generator;
+
+impl Generator {
+    pub fn generate(&self) -> KeyPair {
+        let sk = self.generate_secret();
+        let pk = secp256k1::PublicKey::from_secret_key(&SECP256K1, &sk);
+
+        KeyPair {
+            secret: sk.into(),
+            public: pk.into(),
+        }
+    }
+
+    fn generate_secret(&self) -> secp256k1::SecretKey {
+        let mut seed = vec![0; 32];
+        let mut rng = rand::thread_rng();
+        loop {
+            rng.fill(seed.as_mut_slice());
+            if let Ok(key) = secp256k1::SecretKey::from_slice(&seed) {
+                return key;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::str::FromStr;
+
+    #[test]
+    fn test_key() {
+        let sk: Secret =
+            Secret::from_str("009c0df368efef6084ba35ded33f05ef2a5f4b25d7841bce77e2449be9311dba")
+                .unwrap();
+
+        assert!(sk.public_key().is_ok())
+    }
+
+    #[test]
+    fn test_invalid_key() {
+        let sk = Secret::from_slice(&[0u8; 31]);
+        assert!(sk.is_err());
+
+        let invalid_hex = "009c0df368efef6084ba35ded00000ef2a5f4b25d7841bce77e2449be9311dbx";
+        let sk = Secret::from_str(invalid_hex);
+        assert!(sk.is_err())
+    }
+}

--- a/sdk/src/account/key.rs
+++ b/sdk/src/account/key.rs
@@ -78,6 +78,7 @@ pub struct Public {
 }
 
 impl Public {
+    #[allow(dead_code)]
     pub fn from_slice(data: &[u8]) -> Result<Public, AccountError> {
         Ok(secp256k1::PublicKey::from_slice(data)?.into())
     }
@@ -140,10 +141,12 @@ impl KeyPair {
         Ok(KeyPair { secret, public })
     }
 
+    #[allow(dead_code)]
     pub fn secret(&self) -> &Secret {
         &self.secret
     }
 
+    #[allow(dead_code)]
     pub fn public(&self) -> &Public {
         &self.public
     }

--- a/sdk/src/account/mod.rs
+++ b/sdk/src/account/mod.rs
@@ -1,4 +1,3 @@
-pub use ckb_sdk::traits::{Signer, SecpCkbRawKeySigner};
-pub use ckb_sdk::unlock::{ScriptSigner, ScriptSignError, SecpSighashScriptSigner};
 pub use ckb_crypto::secp::*;
-
+pub use ckb_sdk::traits::{SecpCkbRawKeySigner, Signer};
+pub use ckb_sdk::unlock::{ScriptSignError, ScriptSigner, SecpSighashScriptSigner};

--- a/sdk/src/account/mod.rs
+++ b/sdk/src/account/mod.rs
@@ -1,3 +1,84 @@
+pub use crate::account::error::AccountError;
+use crate::account::key::KeyPair;
+use crate::{
+    account::crypto::Crypto,
+    account::key::{Generator, LockArg},
+};
+use anyhow::Result;
 pub use ckb_crypto::secp::*;
 pub use ckb_sdk::traits::{SecpCkbRawKeySigner, Signer};
 pub use ckb_sdk::unlock::{ScriptSignError, ScriptSigner, SecpSighashScriptSigner};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::{borrow::ToOwned, format, fs, path::Path, string::String};
+
+mod crypto;
+mod error;
+mod key;
+
+// TODO: more fields: id, address(mainnet, testnet)
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub struct Account {
+    pub crypto: Crypto,
+    #[serde(skip)]
+    pub lock_arg: LockArg,
+}
+
+impl Account {
+    pub fn new(password: &[u8]) -> Result<Account, AccountError> {
+        // TODO: maybe we do not need a KeyPair
+        let keypair = Generator::default().generate();
+        Account::from_keypair(keypair, password)
+    }
+
+    /// sk: hex format for the secret key
+    pub fn from_secret(sk: String, password: &[u8]) -> Result<Account, AccountError> {
+        let keypair = KeyPair::from_secret_str(sk)?;
+        Account::from_keypair(keypair, password)
+    }
+
+    pub fn from_file<P: AsRef<Path>>(path: P, password: &[u8]) -> Result<Account, AccountError> {
+        let json_str = fs::read_to_string(path)?;
+        let json_value: Value = serde_json::from_str(&json_str)?;
+        let crypto: Crypto = serde_json::from_value(json_value.get("crypto").unwrap().to_owned())?;
+        let key = crypto.decrypt_key(password)?;
+        let keypair = KeyPair::from_secret_slice(&key)?;
+        Ok(Account {
+            crypto,
+            lock_arg: keypair.lock_arg()?,
+        })
+    }
+
+    pub fn lock_arg_hex(&self) -> String {
+        format!("{:x}", self.lock_arg)
+    }
+
+    fn from_keypair(keypair: KeyPair, password: &[u8]) -> Result<Account, AccountError> {
+        let crypto = Crypto::encrypt_key(keypair.secret().as_bytes(), password);
+        Ok(Account {
+            crypto,
+            lock_arg: keypair.lock_arg()?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_from_file() {
+        let password = b"testpass";
+        let root = tempdir().unwrap();
+        let path = root.path().join("keyfile");
+        let account = Account::new(password).unwrap();
+        fs::write(&path, serde_json::to_string_pretty(&account).unwrap()).unwrap();
+
+        let account2 = Account::from_file(&path, password).unwrap();
+        assert_eq!(account, account2);
+
+        let account3 = Account::from_file(&path, b"invalid");
+        assert!(account3.is_err());
+    }
+}

--- a/sdk/src/contract/builtins/t_nft/mod.rs
+++ b/sdk/src/contract/builtins/t_nft/mod.rs
@@ -3,9 +3,6 @@ use std::prelude::v1::*;
 pub mod mol_defs;
 use crate::ckb_types::{bytes::Bytes, prelude::*};
 
-use mol_defs::{Byte32, Byte32Reader, NFTBuilder, NFT};
-
-
 use crate::contract::Contract;
 use crate::{
     contract::schema::SchemaPrimitiveType,
@@ -13,6 +10,7 @@ use crate::{
     impl_entity_unpack, impl_pack_for_fixed_byte_array, impl_primitive_reader_unpack,
 };
 
+pub use mol_defs::*;
 
 pub trait NftContentHasher {
     fn hash(content: impl AsRef<[u8]>) -> mol_defs::Byte32;
@@ -76,7 +74,6 @@ impl MolConversion for TrampolineNFT {
         }
     }
 }
-
 
 pub type TrampolineNFTContract =
     Contract<SchemaPrimitiveType<Bytes, ckb_types::packed::Bytes>, TrampolineNFT>;

--- a/sdk/src/contract/schema.rs
+++ b/sdk/src/contract/schema.rs
@@ -1,9 +1,8 @@
-
 pub use ckb_jsonrpc_types::JsonBytes;
 
+use crate::ckb_types::{bytes::Bytes, prelude::*};
 use std::marker::PhantomData;
 use std::prelude::v1::*;
-use crate::ckb_types::{bytes::Bytes, prelude::*};
 
 pub trait JsonByteConversion {
     fn to_json_bytes(&self) -> JsonBytes;
@@ -31,10 +30,6 @@ pub trait BytesConversion: MolConversion {
     fn to_bytes(&self) -> Bytes;
 }
 
-// TO DO: Think about the tradeoffs of deriving these traits?
-// This is a wrapper type for schema primitive types that works
-// for all primitives that have conversion trait implemented.
-// Saves from having to implement mol conversion traits etc
 #[derive(Clone, Debug, Default, Eq, PartialEq, Hash)]
 pub struct SchemaPrimitiveType<T, M> {
     pub inner: T,

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -1,13 +1,10 @@
-
 pub mod rpc;
-
 
 pub mod chain;
 
 pub mod contract;
 
 pub mod account;
-
 
 pub mod ckb_types {
     pub use ckb_types::*;

--- a/sdk/tests/sudt_contract.rs
+++ b/sdk/tests/sudt_contract.rs
@@ -1,6 +1,7 @@
 extern crate ckb_always_success_script;
 extern crate trampoline_sdk;
 
+use ckb_types::packed::CellOutputBuilder;
 use trampoline_sdk::chain::{MockChain, MockChainTxProvider as ChainRpc};
 use trampoline_sdk::contract::*;
 use trampoline_sdk::contract::{builtins::sudt::*, generator::*, schema::*};
@@ -335,7 +336,7 @@ fn test_contract_pack_and_unpack_data() {
 fn test_sudt_data_hash_gen_json() {
     let sudt_contract = gen_sudt_contract(None, None);
 
-    let json_code_hash = ckb_jsonrpc_types::Byte32::from(sudt_contract.data_hash().unwrap().pack());
+    let json_code_hash = ckb_jsonrpc_types::Byte32::from(sudt_contract.code_hash().unwrap().pack());
 
     let as_json_hex_str = serde_json::to_string(&json_code_hash).unwrap();
 
@@ -346,10 +347,22 @@ fn test_sudt_data_hash_gen_json() {
 }
 
 #[test]
-fn test_sudt_data_hash_gen() {
-    let sudt_contract = gen_sudt_contract(None, None);
+fn test_sudt_code_hash_gen() {
+    let mut sudt_contract = gen_sudt_contract(None, None);
 
-    let code_hash = sudt_contract.data_hash().unwrap().pack();
+    let code_hash = sudt_contract.code_hash().unwrap().pack();
     let hash_hex_str = format!("0x{}", hex::encode(&code_hash.raw_data()));
     assert_eq!(EXPECTED_SUDT_HASH, hash_hex_str.as_str());
+}
+
+#[test]
+fn test_data_hash_is_accurate() {
+    let mut sudt_contract = gen_sudt_contract(None, None);
+    sudt_contract.set_data(SchemaPrimitiveType::from(123_u128));
+    let data_hash = sudt_contract.data_hash().unwrap().pack();
+    let cell_output = CellOutput::calc_data_hash(123_u128.pack().as_slice());
+    assert_eq!(data_hash.as_slice(), cell_output.as_slice());
+    sudt_contract.set_data(SchemaPrimitiveType::from(124_u128));
+    let data_hash = sudt_contract.data_hash().unwrap().pack();
+    assert_ne!(data_hash.as_slice(), cell_output.as_slice());
 }

--- a/sdk/tests/sudt_contract.rs
+++ b/sdk/tests/sudt_contract.rs
@@ -67,6 +67,7 @@ fn gen_sudt_contract(
         code: Some(JsonBytes::from_bytes(sudt_src)),
         output_rules: vec![],
         input_rules: vec![],
+        outputs_count: 1,
     }
 }
 

--- a/src/account.rs
+++ b/src/account.rs
@@ -1,50 +1,69 @@
-use std::fs;
 use std::path::{Path, PathBuf};
-use std::str::FromStr;
+use std::{fs, process};
 
+use crate::opts::AccountCommand;
+use crate::project::TrampolineProject;
 use anyhow::Result;
-use ckb_types::H160;
-use rand::Rng;
-use thiserror::Error;
+use rpassword::prompt_password;
+use trampoline_sdk::account::{Account, AccountError};
 
-#[derive(Debug, Error)]
-pub enum AccountError {
-    #[error("malformed or out-of-range secret key")]
-    InvalidSecretKey(#[from] secp256k1::Error),
-
-    #[error("Error occurred: {0:?}")]
-    Io(#[from] std::io::Error),
+pub struct AccountSubCommand {
+    project: TrampolineProject,
 }
 
-#[derive(Debug, PartialEq)]
-pub struct Account {
-    sk: secp256k1::SecretKey,
-    lock_arg: H160,
+impl AccountSubCommand {
+    pub fn new(project: TrampolineProject) -> Self {
+        AccountSubCommand { project }
+    }
+
+    pub fn process(&self, command: AccountCommand) {
+        match self.process_inner(command) {
+            Ok(s) => println!("{}", s),
+            Err(e) => {
+                eprintln!("{}", e);
+                process::exit(1);
+            }
+        }
+    }
+
+    fn process_inner(&self, command: AccountCommand) -> Result<String, String> {
+        let mgr = AccountManager::new(self.project.root_dir.join(".trampoline").join("accounts"));
+        match command {
+            AccountCommand::New {} => {
+                let password = read_password(true, None)?;
+                let account = mgr
+                    .create_account(password.as_bytes())
+                    .map_err(|e| format!("{}", e))?;
+                Ok(format!("Account Created\n{}", json_account(&account)))
+            }
+            AccountCommand::Import { sk } => {
+                let password = read_password(true, None)?;
+                let account = mgr
+                    .import_account(sk, password.as_bytes())
+                    .map_err(|e| format!("{}", e))?;
+                Ok(format!("Account Imported\n{}", json_account(&account),))
+            }
+        }
+    }
 }
 
-impl Account {
-    pub fn from_sk(sk: secp256k1::SecretKey) -> Result<Self, AccountError> {
-        let pk = secp256k1::PublicKey::from_secret_key(&ckb_crypto::secp::SECP256K1, &sk);
-        // calling `unwrap` is safe here, since we pass the expected length of bytes.
-        let lock_arg =
-            H160::from_slice(&ckb_hash::blake2b_256(&pk.serialize()[..])[0..20]).unwrap();
-        Ok(Account { sk, lock_arg })
+fn read_password(repeat: bool, prompt: Option<&str>) -> Result<String, String> {
+    let prompt = prompt.unwrap_or("Password: ");
+    let pass = prompt_password(prompt).map_err(|err| err.to_string())?;
+    if repeat {
+        let repeat_pass = prompt_password("Repeat password: ").map_err(|err| err.to_string())?;
+        if pass != repeat_pass {
+            return Err("Passwords do not match".to_owned());
+        }
     }
+    Ok(pass)
+}
 
-    pub fn sk_hex(&self) -> String {
-        format!("{:x}", self.sk)
-    }
-
-    pub fn lock_arg_hex(&self) -> String {
-        format!("{:x}", self.lock_arg)
-    }
-
-    pub fn to_json(&self) -> serde_json::Value {
-        serde_json::json!({
-            "sk": self.sk_hex(),
-            "lock_arg": self.lock_arg_hex()
-        })
-    }
+fn json_account(account: &Account) -> String {
+    let value = serde_json::json!({
+        "lock_arg": account.lock_arg_hex()
+    });
+    serde_json::to_string_pretty(&value).unwrap()
 }
 
 pub struct AccountManager {
@@ -53,70 +72,52 @@ pub struct AccountManager {
 
 impl AccountManager {
     pub fn new<P: AsRef<Path>>(root_dir: P) -> Self {
-        return AccountManager {
+        AccountManager {
             root_dir: root_dir.as_ref().into(),
-        };
+        }
     }
 
     /// Create an account, save the hex-formatted secret key to a file.
     /// The file name is the hex-formatted lock_arg.
-    pub fn create_account(&self) -> Result<Account> {
-        let sk = gen_secret_key();
-        let account = Account::from_sk(sk)?;
+    pub fn create_account(&self, password: &[u8]) -> Result<Account, AccountError> {
+        let account = Account::new(password)?;
         self.write_account(&account)?;
         Ok(account)
     }
 
     /// Import an account using hex-formatted secret key, save it to file.
     /// The file name is the hex-formatted lock_arg.
-    pub fn import_account(&self, sk_string: String) -> Result<Account, AccountError> {
-        let sk = secp256k1::SecretKey::from_str(&sk_string)?;
-        let account = Account::from_sk(sk)?;
+    pub fn import_account(
+        &self,
+        sk_string: String,
+        password: &[u8],
+    ) -> Result<Account, AccountError> {
+        let account = Account::from_secret(sk_string, password)?;
         self.write_account(&account)?;
         Ok(account)
     }
 
     fn write_account(&self, account: &Account) -> Result<(), AccountError> {
         let file = self.root_dir.join(account.lock_arg_hex());
-        fs::write(file, account.sk_hex())?;
+        fs::write(file, serde_json::to_string_pretty(account)?)?;
         Ok(())
     }
 }
 
-fn gen_secret_key() -> secp256k1::SecretKey {
-    let mut seed = vec![0; 32];
-    let mut rng = rand::thread_rng();
-    loop {
-        rng.fill(seed.as_mut_slice());
-        if let Ok(key) = secp256k1::SecretKey::from_slice(&seed) {
-            return key;
-        }
-    }
-}
-
-pub fn lock_arg(sk: secp256k1::SecretKey) -> Result<String> {
-    let pk = secp256k1::PublicKey::from_secret_key(&ckb_crypto::secp::SECP256K1, &sk);
-    let lock_arg = H160::from_slice(&ckb_hash::blake2b_256(&pk.serialize()[..])[0..20])?;
-    Ok(format!("{:x}", lock_arg))
-}
-
 #[cfg(test)]
 mod tests {
-    use serde_json::json;
     use tempfile::tempdir;
 
     use super::*;
 
     #[test]
-    fn test_new_account() -> Result<()> {
-        let root = tempdir()?;
+    fn test_new_account() {
+        let root = tempdir().unwrap();
         let mgr = AccountManager::new(&root);
-        let account = mgr.create_account()?;
-        let sk_hex = fs::read_to_string(root.path().join(account.lock_arg_hex()))?;
-        let sk = secp256k1::SecretKey::from_str(&sk_hex)?;
-        let account2 = Account::from_sk(sk)?;
+        let account = mgr.create_account(&[]).unwrap();
+
+        let account2 = Account::from_file(root.path().join(account.lock_arg_hex()), &[]).unwrap();
         assert_eq!(account2, account);
-        Ok(())
     }
 
     #[test]
@@ -125,10 +126,10 @@ mod tests {
         let mgr = AccountManager::new(&root);
 
         let sk_hex = "009c0df368efef6084ba35ded33f05ef2a5f4b25d7841bce77e2449be9311dba";
-        let account = mgr.import_account(sk_hex.into()).unwrap();
-        let sk_file = root.path().join(account.lock_arg_hex());
-        assert!(sk_file.exists());
-        assert_eq!(fs::read_to_string(sk_file).unwrap(), sk_hex);
+        let account = mgr.import_account(sk_hex.into(), &[]).unwrap();
+        let keyfile = root.path().join(account.lock_arg_hex());
+        assert!(keyfile.exists());
+        assert_eq!(account, Account::from_file(keyfile, &[]).unwrap());
     }
 
     #[test]
@@ -137,25 +138,7 @@ mod tests {
         let mgr = AccountManager::new(&root);
 
         let sk_hex = "009c0df368efef6084ba35ded00000ef2a5f4b25d7841bce77e2449be9311dbx";
-        let result = mgr.import_account(sk_hex.into());
+        let result = mgr.import_account(sk_hex.into(), &[]);
         assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_to_json() {
-        let sk = secp256k1::SecretKey::from_str(
-            "009c0df368efef6084ba35ded33f05ef2a5f4b25d7841bce77e2449be9311dba",
-        )
-        .unwrap();
-        let account = Account::from_sk(sk).unwrap();
-        let json = account.to_json();
-        assert_eq!(
-            json["sk"],
-            json!("009c0df368efef6084ba35ded33f05ef2a5f4b25d7841bce77e2449be9311dba")
-        );
-        assert_eq!(
-            json["lock_arg"],
-            json!("277940df3084136576140e7fa07c3961f0c4cca3")
-        );
     }
 }

--- a/src/bin/trampoline.rs
+++ b/src/bin/trampoline.rs
@@ -9,7 +9,7 @@ use ckb_hash::blake2b_256;
 use ckb_types::{h256, H256};
 
 use structopt::StructOpt;
-use trampoline::account::AccountManager;
+use trampoline::account::AccountSubCommand;
 
 use trampoline::docker::*;
 use trampoline::opts::{AccountCommand, NetworkCommands, SchemaCommand, TrampolineCommand};
@@ -254,25 +254,7 @@ fn main() -> Result<()> {
             }
         }
         TrampolineCommand::Account { command } => {
-            let project = TrampolineProject::from(project?);
-            let mgr = AccountManager::new(project.root_dir.join(".trampoline").join("accounts"));
-
-            match command {
-                AccountCommand::New {} => {
-                    let account = mgr.create_account()?;
-                    println!(
-                        "Account Created\n{}",
-                        serde_json::to_string_pretty(&account.to_json()).unwrap()
-                    );
-                }
-                AccountCommand::Import { sk } => {
-                    let account = mgr.import_account(sk)?;
-                    println!(
-                        "Account Imported\n{}",
-                        serde_json::to_string_pretty(&account.to_json()).unwrap()
-                    );
-                }
-            }
+            AccountSubCommand::new(TrampolineProject::from(project?)).process(command)
         }
     }
 

--- a/src/bin/trampoline.rs
+++ b/src/bin/trampoline.rs
@@ -12,7 +12,7 @@ use structopt::StructOpt;
 use trampoline::account::AccountSubCommand;
 
 use trampoline::docker::*;
-use trampoline::opts::{AccountCommand, NetworkCommands, SchemaCommand, TrampolineCommand};
+use trampoline::opts::{NetworkCommands, SchemaCommand, TrampolineCommand};
 use trampoline::parse_hex;
 use trampoline::project::*;
 use trampoline::schema::{Schema, SchemaInitArgs};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
+pub mod account;
 pub mod docker;
 pub mod opts;
 pub mod project;
 pub mod schema;
 mod utils;
-pub mod account;
 
 use anyhow::{anyhow, Result};
 use lazy_static::lazy_static;


### PR DESCRIPTION
Hi
I re-implement account creation and import with encryption. Please take a look, thanks.
1. As you mentioned before, `Account` needs to work with various lock designs.`. I introduce  `Secret` and `Public` key abstraction, but it seems impossible to work with other ckb libraries without exporting the underlying secp256k1 key 
2. The account encryption and decryption are almost as same as the `ckb-cli`. Maybe this logic could be in the `ckb-sdk` in the future
